### PR TITLE
Update branch names in GitHub workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,9 +3,9 @@ name: Build & deploy .NET APP
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   wowshop_image: '${{ secrets.DOCKER_HUB_USERNAME }}/wowshop'
@@ -40,7 +40,7 @@ jobs:
       run: docker push ${{ env.wowshop_image }}
     
   deploy:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     environment:


### PR DESCRIPTION
Changed branch names in the GitHub workflow from "master" to "main". This is in accordance with the recent change in GitHub's default branch naming convention. All instances of "master" are replaced with "main" to ensure our workflows trigger as expected.